### PR TITLE
[Deprecated] Removing pid_dir

### DIFF
--- a/templates/cs_config _org.j2
+++ b/templates/cs_config _org.j2
@@ -1,6 +1,5 @@
 common:
   daemonize: true
-  pid_dir: /var/run/
   log_media: file
   log_level: info
   log_dir: /var/log/

--- a/templates/cs_config.j2
+++ b/templates/cs_config.j2
@@ -1,6 +1,5 @@
 common:
   daemonize: true
-  pid_dir: /var/run/
   log_media: file
   log_level: info
   log_dir: /var/log/


### PR DESCRIPTION
Hi Alf,

I noticed that the crowdsec configuration no longer requires the pid_dir entry in the config file, as it is deprecated.